### PR TITLE
Sanitize error data

### DIFF
--- a/lib/eview/helpers/sanitization.ex
+++ b/lib/eview/helpers/sanitization.ex
@@ -1,4 +1,6 @@
 defmodule EView.Helpers.Sanitizer do
+  @moduledoc false
+
   def sanitize(term) when is_list(term) do
     for item <- term, into: [], do: sanitize(item)
   end

--- a/lib/eview/helpers/sanitization.ex
+++ b/lib/eview/helpers/sanitization.ex
@@ -1,0 +1,17 @@
+defmodule EView.Helpers.Sanitizer do
+  def sanitize(term) when is_list(term) do
+    for item <- term, into: [], do: sanitize(item)
+  end
+
+  def sanitize(term) when is_map(term) do
+    for {key, value} <- term, into: %{}, do: {key, sanitize(value)}
+  end
+
+  def sanitize(term) when is_tuple(term) do
+    term
+    |> Tuple.to_list
+    |> sanitize()
+  end
+
+  def sanitize(term), do: term
+end

--- a/lib/eview/views/validation_error_view.ex
+++ b/lib/eview/views/validation_error_view.ex
@@ -18,6 +18,8 @@ defmodule EView.Views.ValidationError do
           |> render(EView.Views.ValidationError, "422.json", changeset)
       end
   """
+  alias EView.Helpers.Sanitizer
+
   if Code.ensure_loaded?(Ecto) do
     @doc """
     Use this render template whenever you want to return validation error. Currently is supports:
@@ -58,7 +60,7 @@ defmodule EView.Views.ValidationError do
       %{
         entry_type: "json_data_property",
         entry: path,
-        rules: [rule]
+        rules: [Sanitizer.sanitize(rule)]
       }
     end
   end

--- a/test/unit/sanitizer_test.exs
+++ b/test/unit/sanitizer_test.exs
@@ -1,0 +1,17 @@
+defmodule EView.Helpers.SanitizerTest do
+  use ExUnit.Case, async: true
+
+  alias EView.Helpers.Sanitizer
+
+  test "turns tuples into lists" do
+    assert [:hello, :world] = Sanitizer.sanitize({:hello, :world})
+  end
+
+  test "turns map into sanitized maps" do
+    assert %{a: [1, 2]} = Sanitizer.sanitize(%{a: {1,2}})
+  end
+
+  test "turns lists into sanitized lists" do
+    assert [[1, 2], [3, 4]] = Sanitizer.sanitize([{1, 2}, {3, 4}])
+  end
+end


### PR DESCRIPTION
It's impossible to render tuples to JSON. The PR fixes it by performing
sanitization: tuples are transformed to lists.

This bug was causing en error in gateway, where after validating json against a json schema,
we were getting a tuple, `{:less_than, 0}`, for which there is no representation in JSON.

```
  Request: POST /tr/portfolio_subscriptions
  ** (exit) an exception was raised:
      ** (Poison.EncodeError) unable to encode value: {:less_than, 0}
          (poison) lib/poison/encoder.ex:354: Poison.Encoder.Any.encode/2
          (poison) lib/poison/encoder.ex:232: anonymous fn/3 in Poison.Encoder.List.encode/3
          (poison) lib/poison/encoder.ex:233: Poison.Encoder.List.encode/3
          (poison) lib/poison/encoder.ex:213: anonymous fn/4 in Poison.Encoder.Map.encode/3
          (poison) lib/poison/encoder.ex:214: Poison.Encoder.Map."-encode/3-lists^foldl/2-0-"/3
          (poison) lib/poison/encoder.ex:214: Poison.Encoder.Map.encode/3
          (poison) lib/poison/encoder.ex:232: anonymous fn/3 in Poison.Encoder.List.encode/3
          (poison) lib/poison/encoder.ex:233: Poison.Encoder.List.encode/3
```