### PR TITLE
Implementing for {:array, :map} validation

### DIFF
--- a/lib/eview/helpers/changeset_validations_parser.ex
+++ b/lib/eview/helpers/changeset_validations_parser.ex
@@ -43,15 +43,10 @@ if Code.ensure_loaded?(Ecto) do
     defp get_rule(field, validation_name, validations, message, opts) do
       %{
         description: message |> get_rule_description(opts),
-        rule: get_rule(opts),
+        rule: opts[:validation],
         params: field |> reduce_rule_params(validation_name, validations) |> cast_rules_type()
       }
     end
-
-    defp get_rule([validation: validation]), do: validation
-    defp get_rule([_, validation: validation]), do: validation
-    defp get_rule([validation, _]), do: validation
-    defp get_rule([type: {validation, _incoming}]), do: validation
 
     defp get_rule_description(message, opts) do
       Enum.reduce(opts, message, fn

--- a/lib/eview/helpers/changeset_validations_parser.ex
+++ b/lib/eview/helpers/changeset_validations_parser.ex
@@ -43,10 +43,13 @@ if Code.ensure_loaded?(Ecto) do
     defp get_rule(field, validation_name, validations, message, opts) do
       %{
         description: message |> get_rule_description(opts),
-        rule: opts[:validation],
+        rule: get_rule_key(opts[:validation]),
         params: field |> reduce_rule_params(validation_name, validations) |> cast_rules_type()
       }
     end
+
+    defp get_rule_key(nil), do: :cast
+    defp get_rule_key(rule), do: rule
 
     defp get_rule_description(message, opts) do
       Enum.reduce(opts, message, fn

--- a/lib/eview/helpers/changeset_validations_parser.ex
+++ b/lib/eview/helpers/changeset_validations_parser.ex
@@ -28,6 +28,10 @@ if Code.ensure_loaded?(Ecto) do
       [{field, {:cast, opts[:type]}} | validations]
     end
 
+    defp put_validation(validations, nil, field, opts) do
+      [{field, {nil, opts[:type]}} | validations]
+    end
+
     # Special case for metadata validator that can't modify to changeset validations
     defp put_validation(validations, :length, field, opts) do
       validation = Keyword.take(opts, [:min, :max, :is])
@@ -39,10 +43,15 @@ if Code.ensure_loaded?(Ecto) do
     defp get_rule(field, validation_name, validations, message, opts) do
       %{
         description: message |> get_rule_description(opts),
-        rule: opts[:validation],
+        rule: get_rule(opts),
         params: field |> reduce_rule_params(validation_name, validations) |> cast_rules_type()
       }
     end
+
+    defp get_rule([validation: validation]), do: validation
+    defp get_rule([_, validation: validation]), do: validation
+    defp get_rule([validation, _]), do: validation
+    defp get_rule([type: {validation, _incoming}]), do: validation
 
     defp get_rule_description(message, opts) do
       Enum.reduce(opts, message, fn
@@ -52,6 +61,9 @@ if Code.ensure_loaded?(Ecto) do
 
         {key, {:array, Ecto.UUID}}, acc ->
           String.replace(acc, "%{#{key}}", "uuid")
+
+        {key, {:array, :map}}, acc ->
+          String.replace(acc, "%{#{key}}", "array")
 
         # Everything else is a string
         {key, value}, acc ->
@@ -78,6 +90,10 @@ if Code.ensure_loaded?(Ecto) do
         # Ecto.UUID rule
         {^validation_name, {:array, Ecto.UUID}}, acc ->
           [:uuid | acc]
+
+        # Ecto {:array, :map} rule
+        {^validation_name, {:array, :map}}, acc ->
+          [:map | acc]
 
         # Or at least parseable
         {^validation_name, rule_description}, acc ->

--- a/test/unit/changeset_validations_parser_test.exs
+++ b/test/unit/changeset_validations_parser_test.exs
@@ -138,7 +138,7 @@ defmodule EView.ChangesetValidationsParserTest do
         rules: [
           %{
             description: "is invalid",
-            rule: nil,
+            rule: :cast,
             params: [:map]
           }
         ]

--- a/test/unit/changeset_validations_parser_test.exs
+++ b/test/unit/changeset_validations_parser_test.exs
@@ -128,6 +128,24 @@ defmodule EView.ChangesetValidationsParserTest do
     ]} = EView.Views.ValidationError.render("422.json", changeset)
   end
 
+  test "cast map instead list" do
+    changeset = %{posts: %{upvotes: 11}}
+    |> blog_changeset()
+
+    assert %{invalid: [
+      %{
+        entry: "$.posts",
+        rules: [
+          %{
+            description: "is invalid",
+            rule: :array,
+            params: [:map]
+          }
+        ]
+      }
+    ]} = EView.Views.ValidationError.render("422.json", changeset)
+  end
+
   test "validate_required/2" do
     changeset = %{} |> changeset() |> validate_required(:title)
     refute changeset.valid?

--- a/test/unit/changeset_validations_parser_test.exs
+++ b/test/unit/changeset_validations_parser_test.exs
@@ -138,7 +138,7 @@ defmodule EView.ChangesetValidationsParserTest do
         rules: [
           %{
             description: "is invalid",
-            rule: :array,
+            rule: nil,
             params: [:map]
           }
         ]


### PR DESCRIPTION
Fix the next error

    ** (exit) an exception was raised: 
    ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:array, :map}
        (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
        (elixir) lib/string/chars.ex:17: String.Chars.to_string/1
        (eview) lib/eview/helpers/changeset_validations_parser.ex:59: anonymous fn/2 in EView.Helpers.ChangesetValidationsParser.get_rule_description/2
        (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
        (eview) lib/eview/helpers/changeset_validations_parser.ex:45: EView.Helpers.ChangesetValidationsParser.get_rule/5
        (ecto) lib/ecto/changeset.ex:2136: anonymous fn/4 in Ecto.Changeset.merge_error_keys/3
        (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
        (ecto) lib/ecto/changeset.ex:2123: Ecto.Changeset.traverse_errors/2`

In case if you have has_many relation and trying to cast map instead array