### PR TITLE
Handle exceptions

### DIFF
--- a/lib/eview.ex
+++ b/lib/eview.ex
@@ -30,6 +30,8 @@ defmodule EView do
     do: conn
   defp update_reponse_body(%{resp_body: nil} = conn),
     do: conn
+  defp update_reponse_body(%{resp_body: "<" <> resp_body} = conn),
+    do: %{conn | resp_body: resp_body}
   defp update_reponse_body(%{resp_body: resp_body} = conn) do
     resp = resp_body
     |> Poison.Parser.parse!


### PR DESCRIPTION
Do not try to parse/wrap server response in case server code raised exception, and an HTML is being returned.

It's a hacky solution until a proper one is invented.